### PR TITLE
[Feat] Swagger(OpenAPI) 기반 API 문서화 및 인증 연동

### DIFF
--- a/src/main/java/com/shcho/myBlog/MyBlogApplication.java
+++ b/src/main/java/com/shcho/myBlog/MyBlogApplication.java
@@ -2,8 +2,10 @@ package com.shcho.myBlog;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class MyBlogApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/shcho/myBlog/common/config/SecurityConfig.java
+++ b/src/main/java/com/shcho/myBlog/common/config/SecurityConfig.java
@@ -1,0 +1,31 @@
+package com.shcho.myBlog.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth
+                        // Swagger 관련 경로 허용
+                        .requestMatchers(
+                                "/v3/api-docs/**",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html"
+                        ).permitAll()
+                        // 그 외 경로는 인증 필요
+                        .anyRequest().authenticated()
+                )
+                .httpBasic(Customizer.withDefaults());
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/shcho/myBlog/common/config/SwaggerConfig.java
+++ b/src/main/java/com/shcho/myBlog/common/config/SwaggerConfig.java
@@ -1,0 +1,24 @@
+package com.shcho.myBlog.common.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+        info = @Info(
+                title = "ShBlog API",
+                version = "v1",
+                description = "개인 블로그 프로젝트 백엔드 API 명세"
+        )
+)
+@SecurityScheme(
+        name = "bearerAuth",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT"
+)
+public class SwaggerConfig {
+}


### PR DESCRIPTION
## ✅ 작업 내용
- Swagger(OpenAPI) 기반 API 문서화 설정 추가
- Swagger UI에서 Bearer(JWT) 인증 스키마(Authorize) 등록
- Spring Security에서 Swagger 관련 경로만 접근 허용 설정 추가

## 🔧 변경사항
- `SwaggerConfig.java`
- `SecurityConfig.java`

## 📌 관련 이슈
- Closes #3