### PR TITLE
[Issue] UploadFile 정리 배치 작업 구현 (TEMP TTL + DELETED purge)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,69 +1,72 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.5.3'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '3.5.3'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.shcho'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
 
-	// mariaDB
-	implementation 'org.mariadb.jdbc:mariadb-java-client:3.1.4'
+    // mariaDB
+    implementation 'org.mariadb.jdbc:mariadb-java-client:3.1.4'
 
-	// swagger
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+    // swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
-	// queryDsl
-	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-	annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
-	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
-	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+    // queryDsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 
-	// minio
-	implementation 'io.minio:minio:8.5.7'
+    // minio
+    implementation 'io.minio:minio:8.5.7'
 
-	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
-	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
-	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+    // spring-batch
+    implementation 'org.springframework.boot:spring-boot-starter-batch'
 
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.h2database:h2'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }
 
 def querydslDir = "$buildDir/generated/querydsl"
 
 sourceSets {
-	main.java.srcDirs += querydslDir
+    main.java.srcDirs += querydslDir
 }
 
 tasks.withType(JavaCompile).configureEach {
-	options.annotationProcessorGeneratedSourcesDirectory = file(querydslDir)
+    options.annotationProcessorGeneratedSourcesDirectory = file(querydslDir)
 }
 
 tasks.named('compileJava') {
-	options.annotationProcessorPath = configurations.annotationProcessor
+    options.annotationProcessorPath = configurations.annotationProcessor
 }

--- a/src/main/java/com/shcho/myBlog/common/config/SchedulingConfig.java
+++ b/src/main/java/com/shcho/myBlog/common/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package com.shcho.myBlog.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}

--- a/src/main/java/com/shcho/myBlog/common/config/UploadFileCleanupJobConfig.java
+++ b/src/main/java/com/shcho/myBlog/common/config/UploadFileCleanupJobConfig.java
@@ -1,0 +1,161 @@
+package com.shcho.myBlog.common.config;
+
+import com.shcho.myBlog.common.entity.UploadFile;
+import com.shcho.myBlog.common.entity.UploadStatus;
+import com.shcho.myBlog.common.repository.UploadFileRepository;
+import com.shcho.myBlog.common.service.MinioService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.data.RepositoryItemReader;
+import org.springframework.batch.item.data.builder.RepositoryItemReaderBuilder;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.Sort;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Map;
+
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class UploadFileCleanupJobConfig {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+
+    private final UploadFileRepository uploadFileRepository;
+    private final MinioService minioService;
+
+    @Value("${cleanup.temp-ttl-hours:24}")
+    private Long tempTtlHours;
+
+    @Value("${cleanup.deleted-retention-days:7}")
+    private Long deletedRetentionDays;
+
+    @Bean
+    public Job uploadFileCleanupJob(
+            @Qualifier("cleanupTempFilesStep") Step cleanupTempFilesStep,
+            @Qualifier("purgeDeletedFilesStep") Step purgeDeletedFilesStep
+    ) {
+        return new JobBuilder("uploadFileCleanupJob", jobRepository)
+                .start(cleanupTempFilesStep)
+                .next(purgeDeletedFilesStep)
+                .build();
+    }
+
+    @Bean("cleanupTempFilesStep")
+    public Step cleanupTempFilesStep(
+            @Qualifier("tempFilesReader") RepositoryItemReader<UploadFile> tempFilesReader
+    ) {
+        return new StepBuilder("cleanupTempFilesStep", jobRepository)
+                .<UploadFile, UploadFile>chunk(100, transactionManager)
+                .reader(tempFilesReader)
+                .writer(tempFilesWriter())
+                .build();
+    }
+
+    @Bean("purgeDeletedFilesStep")
+    public Step purgeDeletedFilesStep(
+            @Qualifier("deletedFilesReader") RepositoryItemReader<UploadFile> deletedFilesReader
+    ) {
+        return new StepBuilder("purgeDeletedFilesStep", jobRepository)
+                .<UploadFile, UploadFile>chunk(100, transactionManager)
+                .reader(deletedFilesReader)
+                .writer(deletedFilesWriter())
+                .build();
+    }
+
+    @Bean("tempFilesReader")
+    @StepScope
+    public RepositoryItemReader<UploadFile> tempFilesReader(
+            @Value("#{jobParameters['runAt']}") Long runAt
+    ) {
+        LocalDateTime cutoff = LocalDateTime.ofInstant(
+                Instant.ofEpochMilli(runAt),
+                ZoneId.of("Asia/Seoul")
+        ).minusHours(tempTtlHours);
+
+        return new RepositoryItemReaderBuilder<UploadFile>()
+                .name("tempFilesReader")
+                .repository(uploadFileRepository)
+                .methodName("findAllByStatusAndCreatedAtBefore")
+                .arguments(UploadStatus.TEMP, cutoff)
+                .sorts(Map.of("id", Sort.Direction.ASC))
+                .pageSize(100)
+                .build();
+    }
+
+    @Bean("deletedFilesReader")
+    @StepScope
+    public RepositoryItemReader<UploadFile> deletedFilesReader(
+            @Value("#{jobParameters['runAt']}") Long runAt
+    ) {
+        LocalDateTime cutoff = LocalDateTime.ofInstant(
+                Instant.ofEpochMilli(runAt),
+                ZoneId.of("Asia/Seoul")
+        ).minusDays(deletedRetentionDays);
+
+        return new RepositoryItemReaderBuilder<UploadFile>()
+                .name("deletedFilesReader")
+                .repository(uploadFileRepository)
+                .methodName("findAllByStatusAndDeletedAtBefore")
+                .arguments(UploadStatus.DELETED, cutoff)
+                .sorts(Map.of("id", Sort.Direction.ASC))
+                .pageSize(100)
+                .build();
+    }
+
+    @Bean
+    public ItemWriter<UploadFile> tempFilesWriter() {
+        return items -> {
+            var list = items.getItems();
+
+            for (UploadFile file : list) {
+                try {
+                    minioService.deleteObject(file.getObjectName());
+                    file.markDeleted();
+                } catch (Exception e) {
+                    log.warn("TEMP 파일 MinIO 삭제 실패. uploadFileId={}, objectName={}",
+                            file.getId(), file.getObjectName(), e);
+                }
+            }
+
+            uploadFileRepository.saveAll(list);
+        };
+    }
+
+    @Bean
+    public ItemWriter<UploadFile> deletedFilesWriter() {
+        return items -> {
+            var list = items.getItems();
+            var successIds = new ArrayList<Long>();
+
+            for (UploadFile file : list) {
+                try {
+                    minioService.deleteObject(file.getObjectName());
+                    successIds.add(file.getId());
+                } catch (Exception e) {
+                    log.warn("DELETED 파일 MinIO 삭제 실패. uploadFileId={}, objectName={}",
+                            file.getId(), file.getObjectName(), e);
+                }
+            }
+
+            if (!successIds.isEmpty()) {
+                uploadFileRepository.deleteAllByIdInBatch(successIds);
+            }
+        };
+    }
+}

--- a/src/main/java/com/shcho/myBlog/common/entity/UploadFile.java
+++ b/src/main/java/com/shcho/myBlog/common/entity/UploadFile.java
@@ -6,12 +6,14 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class UploadFile {
+public class UploadFile extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -36,6 +38,8 @@ public class UploadFile {
     @Column(nullable = false)
     private UploadStatus status;
 
+    private LocalDateTime deletedAt;
+
     public void attachToPost(Long postId) {
         this.postId = postId;
         this.status = UploadStatus.ATTACHED;
@@ -43,5 +47,6 @@ public class UploadFile {
 
     public void markDeleted() {
         this.status = UploadStatus.DELETED;
+        this.deletedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/shcho/myBlog/common/repository/UploadFileRepository.java
+++ b/src/main/java/com/shcho/myBlog/common/repository/UploadFileRepository.java
@@ -2,10 +2,17 @@ package com.shcho.myBlog.common.repository;
 
 import com.shcho.myBlog.common.entity.UploadFile;
 import com.shcho.myBlog.common.entity.UploadStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface UploadFileRepository extends JpaRepository<UploadFile, Long> {
     List<UploadFile> findAllByPostIdAndStatus(Long postId, UploadStatus status);
+
+    Page<UploadFile> findAllByStatusAndCreatedAtBefore(UploadStatus status, LocalDateTime cutoff, Pageable pageable);
+
+    Page<UploadFile> findAllByStatusAndDeletedAtBefore(UploadStatus status, LocalDateTime cutoff, Pageable pageable);
 }

--- a/src/main/java/com/shcho/myBlog/common/scheduler/UploadFileCleanupJobScheduler.java
+++ b/src/main/java/com/shcho/myBlog/common/scheduler/UploadFileCleanupJobScheduler.java
@@ -1,0 +1,34 @@
+package com.shcho.myBlog.common.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class UploadFileCleanupJobScheduler {
+
+    private final JobLauncher jobLauncher;
+    private final Job uploadFileCleanupJob;
+
+    @Scheduled(cron = "${cleanup.schedule-cron:0 0 30 * * *}")
+    public void runUploadFileCleanupJob() {
+        Long runAt = System.currentTimeMillis();
+        try {
+            JobParameters params = new JobParametersBuilder()
+                    .addLong("runAt", runAt)
+                    .toJobParameters();
+
+            jobLauncher.run(uploadFileCleanupJob, params);
+            log.info("uploadFileCleanupJob 실행 완료. runAt = {}", runAt);
+        } catch (Exception e) {
+            log.error("uploadFileCleanupJob 실행 실패", e);
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,12 @@ spring:
         format_sql: true
         show_sql: true
 
+  batch:
+    job:
+      enabled: false
+    jdbc:
+      initialize-schema: always
+
 logging:
   level:
     org.hibernate.SQL: debug
@@ -33,3 +39,9 @@ minio:
   secret-key: ${MINIO_SECRET_KEY}
   bucket: shblog
   base-url: https://minio.shhome.synology.me
+
+cleanup:
+  temp-ttl-hours: 24
+  deleted-retention-days: 7
+  schedule-cron: "0 0 3 * * *"
+


### PR DESCRIPTION
## ✅ 작업 내용
- UploadFile 정리용 Spring Batch Job 구현
- TEMP 상태 파일 TTL 초과 시 MinIO 삭제 후 DELETED 전환 처리
- DELETED 상태 파일 retention 기간 초과 시 MinIO 삭제 후 DB 물리 삭제
- 스케줄러를 통한 자동 실행 구성 (매일 03:00)
- RepositoryItemReader 기반 페이징 조회 적용
- 실패 시 재시도 가능한 구조로 설계

## 🔧 변경사항
- UploadFileCleanupJobConfig 신규 구현
    - cleanupTempFilesStep 추가
    - purgeDeletedFilesStep 추가
- RepositoryItemReader 기반 페이징 조회 적용
    - TEMP → createdAt 기준 조회
    - DELETED → deletedAt 기준 조회
- TEMP 만료 파일 처리
    - MinIO 객체 삭제
    - UploadFile 상태 DELETED 변경
    - deletedAt 세팅
- DELETED 만료 파일 처리
    - MinIO 객체 삭제
    - DB row 물리 삭제
- UploadFileRepository 조회 메서드 추가
    - findAllByStatusAndCreatedAtBefore
    - findAllByStatusAndDeletedAtBefore
- UploadFileCleanupJobScheduler 구현
    - cron 기반 자동 실행
    - runAt JobParameter 적용
- application.yml 배치/cleanup 설정 추가

## 🧪 테스트
- DB 직접 insert 후 배치 실행 검증
    - TEMP 만료 → DELETED 전환 확인
    - TEMP 유효 → 유지 확인
    - DELETED 만료 → DB row 삭제 확인
    - DELETED 유효 → 유지 확인
- MinIO 삭제 실패 시 상태 유지 확인 (재시도 가능 구조)

## 📌 관련 이슈
- Closes #41 
