### PR TITLE
[Fix] recent thumbnails 조회 시 첨부파일, 이미지 링크 삭제 안되는 현상 수정

### DIFF
--- a/src/main/java/com/shcho/myBlog/post/service/PostService.java
+++ b/src/main/java/com/shcho/myBlog/post/service/PostService.java
@@ -218,12 +218,14 @@ public class PostService {
             return "";
         }
 
-        String noHtml = content.replaceAll("<[^>]*>", " ");
+        String noHtml = content.replaceAll("<[^>]*>", " "); // HTML
 
         String noMarkdown = noHtml
                 .replaceAll("(?s)```.*?```", " ") // code block
                 .replaceAll("`[^`]*`", " ")       // inline code
-                .replaceAll("[#>*_\\-]", " ");    // tokens
+                .replaceAll("[#>*_\\-]", " ")    // tokens
+                .replaceAll("!\\[[^\\]]*\\]\\([^\\)]*\\)", " ") // image
+                .replaceAll("\\[[^\\]]*\\]\\([^\\)]*\\)", " "); // link
 
         String normalized = noMarkdown
                 .replaceAll("\\s+", " ")

--- a/src/test/java/com/shcho/myBlog/post/service/PostServiceTest.java
+++ b/src/test/java/com/shcho/myBlog/post/service/PostServiceTest.java
@@ -759,6 +759,8 @@ class PostServiceTest {
 
         String rawContent = """
             <p>  안녕   </p>
+            ![img1](https://example.com/a.png)
+            [link](https://example.com)
             # 제목
             ```java
             System.out.println("hi");
@@ -796,6 +798,9 @@ class PostServiceTest {
         assertFalse(r1.summary().contains("\n"));
         assertFalse(r1.summary().contains("  "));
         assertEquals("짧은 내용", result.get(1).summary());
+
+        assertFalse(r1.summary().contains("!["));
+        assertFalse(r1.summary().contains("[link]("));
 
         verify(postQueryRepository, times(1))
                 .findRecentPostsByNickname(nickname, 6);


### PR DESCRIPTION
## ✅ 작업 내용
- recent thumbnails 조회 시 summary 생성 로직에서 이미지 및 첨부 링크가 제거되지 않던 문제 수정
- HTML/Markdown 제거 로직 보완

## 🔧 변경사항
- PostService
    - toSummary() 정규식 보완 (이미지/링크 제거 처리 개선)
- PostServiceTest
    - recent thumbnails 관련 단위 테스트 추가 및 보강

## 🧪 테스트
- 이미지/링크/코드 블록이 summary에 포함되지 않는지 검증

