### PR TITLE
[Feat] 로그인 응답에 accessToken 만료 시간(expiresIn) 추가

### DIFF
--- a/src/main/java/com/shcho/myBlog/common/util/JwtProvider.java
+++ b/src/main/java/com/shcho/myBlog/common/util/JwtProvider.java
@@ -2,6 +2,7 @@ package com.shcho.myBlog.common.util;
 
 import com.shcho.myBlog.libs.exception.CustomException;
 import com.shcho.myBlog.user.entity.Role;
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
@@ -18,6 +19,8 @@ import static com.shcho.myBlog.libs.exception.ErrorCode.JWT_KEY_ERROR;
 @RequiredArgsConstructor
 public class JwtProvider {
 
+    private static final long EXPIRATION_TIME = 1000L * 60L * 60L * 24L;
+
     @Value("${jwt.secret}")
     private String secretKey;
 
@@ -32,7 +35,6 @@ public class JwtProvider {
     }
 
     public String createToken(String username, Role role) {
-        long EXPIRATION_TIME = 1000L * 60L * 60L * 24L;
 
         return Jwts.builder()
                 .subject(username)
@@ -62,5 +64,19 @@ public class JwtProvider {
         } catch (Exception e) {
             return false;
         }
+    }
+
+    public long getExpirationInSeconds(String token) {
+        Claims claims = Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+
+        Date expiration = claims.getExpiration();
+
+        long diffMillis = expiration.getTime() - System.currentTimeMillis();
+
+        return Math.max(0, diffMillis / 1000);
     }
 }

--- a/src/main/java/com/shcho/myBlog/user/controller/AuthController.java
+++ b/src/main/java/com/shcho/myBlog/user/controller/AuthController.java
@@ -35,7 +35,8 @@ public class AuthController {
     ) {
         User user = userService.signIn(requestDto);
         String token = userService.getUserToken(user);
+        long expiresIn = userService.getExpiresInSeconds(token);
 
-        return ResponseEntity.ok(UserSignInResponseDto.of(user, token));
+        return ResponseEntity.ok(UserSignInResponseDto.of(user, token, expiresIn));
     }
 }

--- a/src/main/java/com/shcho/myBlog/user/dto/UserSignInResponseDto.java
+++ b/src/main/java/com/shcho/myBlog/user/dto/UserSignInResponseDto.java
@@ -6,13 +6,16 @@ public record UserSignInResponseDto(
         String accessToken,
         String username,
         String nickname,
-        String email
+        String email,
+        long expiresIn
 ) {
-    public static UserSignInResponseDto of(User user, String token) {
+    public static UserSignInResponseDto of(User user, String token, long expiresIn) {
         return new UserSignInResponseDto(
                 token,
                 user.getUsername(),
                 user.getNickname(),
-                user.getEmail());
+                user.getEmail(),
+                expiresIn
+        );
     }
 }

--- a/src/main/java/com/shcho/myBlog/user/service/UserService.java
+++ b/src/main/java/com/shcho/myBlog/user/service/UserService.java
@@ -84,4 +84,8 @@ public class UserService {
     public String getUserToken(User user) {
         return jwtProvider.createToken(user.getUsername(), user.getRole());
     }
+
+    public long getExpiresInSeconds(String token) {
+        return jwtProvider.getExpirationInSeconds(token);
+    }
 }


### PR DESCRIPTION
## ✅ 작업 내용
- 로그인 응답에 expiresIn 필드 추가
- JWT 토큰에서 만료 시각 파싱하여 남은 시간 계산 로직 구현
- 프론트에서 자동 로그아웃/만료 안내 가능하도록 개선

## 🔧 변경사항
- UserSignInResponseDto
    - expiresIn 필드 추가
- UserService
    - getExpiresInSeconds() 메서드 추가
- JwtProvider
    - getExpirationInSeconds() 구현
- AuthController
    - 로그인 응답 시 expiresIn 포함하도록 수정