### PR TITLE
[Feat] 마이페이지 - 내 정보 수정 기능 구현

### DIFF
--- a/src/main/java/com/shcho/myBlog/common/entity/UploadType.java
+++ b/src/main/java/com/shcho/myBlog/common/entity/UploadType.java
@@ -2,5 +2,6 @@ package com.shcho.myBlog.common.entity;
 
 public enum UploadType {
     IMAGE,
-    ATTACHMENT
+    ATTACHMENT,
+    PROFILE_IMAGE
 }

--- a/src/main/java/com/shcho/myBlog/common/scheduler/UploadFileCleanupJobScheduler.java
+++ b/src/main/java/com/shcho/myBlog/common/scheduler/UploadFileCleanupJobScheduler.java
@@ -17,7 +17,7 @@ public class UploadFileCleanupJobScheduler {
     private final JobLauncher jobLauncher;
     private final Job uploadFileCleanupJob;
 
-    @Scheduled(cron = "${cleanup.schedule-cron:0 0 30 * * *}")
+    @Scheduled(cron = "${cleanup.schedule-cron:0 0 3 * * *}")
     public void runUploadFileCleanupJob() {
         Long runAt = System.currentTimeMillis();
         try {

--- a/src/main/java/com/shcho/myBlog/common/service/MinioService.java
+++ b/src/main/java/com/shcho/myBlog/common/service/MinioService.java
@@ -18,8 +18,7 @@ import java.time.LocalDate;
 import java.util.Set;
 import java.util.UUID;
 
-import static com.shcho.myBlog.common.entity.UploadType.ATTACHMENT;
-import static com.shcho.myBlog.common.entity.UploadType.IMAGE;
+import static com.shcho.myBlog.common.entity.UploadType.*;
 import static com.shcho.myBlog.libs.exception.ErrorCode.*;
 
 @Service
@@ -38,9 +37,11 @@ public class MinioService {
 
     private static final long IMAGE_MAX_SIZE = 10L * 1024 * 1024;
     private static final long ATTACH_MAX_SIZE = 50L * 1024 * 1024;
+    private static final long PROFILE_MAX_SIZE = 2L * 1024 * 1024;
 
     private static final Set<String> IMAGE_EXT = Set.of("jpg", "jpeg", "png", "gif", "webp");
     private static final Set<String> ATTACH_EXT = Set.of("pdf", "zip", "txt", "md");
+    private static final Set<String> PROFILE_EXT = Set.of("jpg", "jpeg", "png", "webp");
 
     public String upload(Long userId, MultipartFile file, UploadType type) {
         validateFile(file, type);
@@ -65,6 +66,11 @@ public class MinioService {
             );
 
             String url = buildFileUrl(objectName);
+
+            if(type == PROFILE_IMAGE) {
+                return url;
+            }
+
             Long fid = uploadFileService.saveTemp(userId, type, objectName, url);
             return uploadFileService.appendFid(url, fid);
         } catch (Exception e) {
@@ -94,21 +100,21 @@ public class MinioService {
         }
 
         long size = file.getSize();
-
-        if (type == IMAGE && size > IMAGE_MAX_SIZE) {
-            throw new CustomException(FILE_TOO_LARGE);
-        }
-        if (type == ATTACHMENT && size > ATTACH_MAX_SIZE) {
-            throw new CustomException(FILE_TOO_LARGE);
-        }
-
         String ext = extractExt(file.getOriginalFilename());
 
-        if (type == IMAGE && !IMAGE_EXT.contains(ext)) {
-            throw new CustomException(INVALID_FILE_EXTENSION);
+        if (type == IMAGE) {
+            if (size > IMAGE_MAX_SIZE) throw new CustomException(FILE_TOO_LARGE);
+            if (!IMAGE_EXT.contains(ext)) throw new CustomException(INVALID_FILE_EXTENSION);
         }
-        if (type == ATTACHMENT && !ATTACH_EXT.contains(ext)) {
-            throw new CustomException(INVALID_FILE_EXTENSION);
+
+        if (type == ATTACHMENT) {
+            if (size > ATTACH_MAX_SIZE) throw new CustomException(FILE_TOO_LARGE);
+            if (!ATTACH_EXT.contains(ext)) throw new CustomException(INVALID_FILE_EXTENSION);
+        }
+
+        if (type == PROFILE_IMAGE) {
+            if (size > PROFILE_MAX_SIZE) throw new CustomException(FILE_TOO_LARGE);
+            if (!PROFILE_EXT.contains(ext)) throw new CustomException(INVALID_FILE_EXTENSION);
         }
     }
 
@@ -127,9 +133,13 @@ public class MinioService {
         LocalDate now = LocalDate.now();
         String yyyy = String.valueOf(now.getYear());
         String mm = String.format("%02d", now.getMonthValue());
+        String uuid = UUID.randomUUID().toString().replace("-", "");
+
+        if (type == UploadType.PROFILE_IMAGE) {
+            return "users/" + userId + "/profile/" + yyyy + "/" + mm + "/" + uuid + "." + ext;
+        }
 
         String folder = (type == IMAGE) ? "images" : "attachments";
-        String uuid = UUID.randomUUID().toString().replace("-", "");
 
         return "users/" + userId + "/" + folder + "/" + yyyy + "/" + mm + "/" + uuid + "." + ext;
     }
@@ -149,5 +159,15 @@ public class MinioService {
             sb.append(URLEncoder.encode(parts[i], StandardCharsets.UTF_8));
         }
         return sb.toString();
+    }
+
+    public String extractObjectNameFromUrl(String fileUrl) {
+        if(fileUrl == null || fileUrl.isBlank()) return null;
+
+        String marker = "/" + bucket + "/";
+        int idx = fileUrl.indexOf(marker);
+        if (idx < 0) return null;
+
+        return fileUrl.substring(idx + marker.length());
     }
 }

--- a/src/main/java/com/shcho/myBlog/libs/exception/ErrorCode.java
+++ b/src/main/java/com/shcho/myBlog/libs/exception/ErrorCode.java
@@ -41,6 +41,8 @@ public enum ErrorCode {
     DUPLICATED_EMAIL(409, "USER_004", "이미 사용 중인 이메일입니다."),
     DUPLICATED_NICKNAME(409, "USER_005", "이미 사용 중인 닉네임입니다."),
     DUPLICATED_CATEGORY_NAME(409, "CATEGORY_001", "이미 사용 중인 카테고리명 입니다."),
+    SAME_USERNAME(409, "USER_006", "이전의 사용하던 아이디와 같습니다."),
+    SAME_NICKNAME(409, "USER_007", "이전에 사용하던 닉네임과 같습니다."),
 
     /* 500 INTERNAL_SERVER_ERROR */
     INTERNAL_SERVER_ERROR(500, "COMMON_500", "서버 오류가 발생했습니다."),

--- a/src/main/java/com/shcho/myBlog/libs/exception/ErrorCode.java
+++ b/src/main/java/com/shcho/myBlog/libs/exception/ErrorCode.java
@@ -20,7 +20,8 @@ public enum ErrorCode {
 
     /* 401 UNAUTHORIZED */
     INVALID_USERNAME_OR_PASSWORD(401, "AUTH_001", "아이디 또는 비밀번호가 올바르지 않습니다."),
-    AUTH_REQUIRED(401, "AUTH_002", "인증이 필요합니다."),
+    AUTH_REQUIRED(401, "USER_002", "인증이 필요합니다."),
+    INVALID_OLD_PASSWORD(401, "USER_006", "이전 비밀번호가 일치하지 않습니다."),
 
     /* 403 FORBIDDEN */
     CATEGORY_FORBIDDEN(403, "CATEGORY_003", "해당 카테고리에 대한 권한이 없습니다."),

--- a/src/main/java/com/shcho/myBlog/libs/exception/ErrorCode.java
+++ b/src/main/java/com/shcho/myBlog/libs/exception/ErrorCode.java
@@ -43,6 +43,7 @@ public enum ErrorCode {
     DUPLICATED_CATEGORY_NAME(409, "CATEGORY_001", "이미 사용 중인 카테고리명 입니다."),
     SAME_USERNAME(409, "USER_006", "이전의 사용하던 아이디와 같습니다."),
     SAME_NICKNAME(409, "USER_007", "이전에 사용하던 닉네임과 같습니다."),
+    SAME_EMAIL(409, "USER_008", "이전에 사용하던 이메일과 같습니다."),
 
     /* 500 INTERNAL_SERVER_ERROR */
     INTERNAL_SERVER_ERROR(500, "COMMON_500", "서버 오류가 발생했습니다."),

--- a/src/main/java/com/shcho/myBlog/user/controller/UserController.java
+++ b/src/main/java/com/shcho/myBlog/user/controller/UserController.java
@@ -1,23 +1,82 @@
 package com.shcho.myBlog.user.controller;
 
 import com.shcho.myBlog.user.auth.CustomUserDetails;
-import com.shcho.myBlog.user.dto.UserMeResponseDto;
+import com.shcho.myBlog.user.dto.*;
 import com.shcho.myBlog.user.entity.User;
+import com.shcho.myBlog.user.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/users")
+@RequiredArgsConstructor
 public class UserController {
+
+    private final UserService userService;
 
     @GetMapping("/me")
     public ResponseEntity<UserMeResponseDto> me(
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         User user = userDetails.getUser();
+        return ResponseEntity.ok(UserMeResponseDto.from(user));
+    }
+
+    @PatchMapping("/me/username")
+    public ResponseEntity<UserMeResponseDto> updateUsername(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody UpdateUsernameRequestDto requestDto
+    ) {
+        User user = userService.updateUsername(userDetails.getUserId(), requestDto);
+        return ResponseEntity.ok(UserMeResponseDto.from(user));
+    }
+
+    @PatchMapping("/me/password")
+    public ResponseEntity<UserMeResponseDto> updateUserPassword(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody UpdateUserPasswordRequestDto requestDto
+    ) {
+        User user = userService.updateUserPassword(userDetails.getUserId(), requestDto);
+        return ResponseEntity.ok(UserMeResponseDto.from(user));
+    }
+
+    @PatchMapping("/me/nickname")
+    public ResponseEntity<UserMeResponseDto> updateUserNickname(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody UpdateUserNicknameRequestDto requestDto
+    ) {
+        User user = userService.updateUserNickname(userDetails.getUserId(), requestDto);
+        return ResponseEntity.ok(UserMeResponseDto.from(user));
+    }
+
+    @PatchMapping("/me/email")
+    public ResponseEntity<UserMeResponseDto> updateUserEmail(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody UpdateUserEmailRequestDto requestDto
+    ) {
+        User user = userService.updateUserEmail(userDetails.getUserId(), requestDto);
+        return ResponseEntity.ok(UserMeResponseDto.from(user));
+    }
+
+    @PutMapping(value = "/me/profile-image", consumes = "multipart/form-data")
+    public ResponseEntity<UserMeResponseDto> updateUserProfileImage(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam("file") MultipartFile file
+    ) {
+        User user = userService.updateUserProfileImage(userDetails.getUserId(), file);
+
+        return ResponseEntity.ok(UserMeResponseDto.from(user));
+    }
+
+    @DeleteMapping("/me/profile-image")
+    public ResponseEntity<UserMeResponseDto> deleteUserProfileImage(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        User user = userService.deleteUserProfileImage(userDetails.getUserId());
         return ResponseEntity.ok(UserMeResponseDto.from(user));
     }
 }

--- a/src/main/java/com/shcho/myBlog/user/dto/UpdateUserEmailRequestDto.java
+++ b/src/main/java/com/shcho/myBlog/user/dto/UpdateUserEmailRequestDto.java
@@ -1,0 +1,9 @@
+package com.shcho.myBlog.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateUserEmailRequestDto(
+        @NotBlank @Email String email
+) {
+}

--- a/src/main/java/com/shcho/myBlog/user/dto/UpdateUserNicknameRequestDto.java
+++ b/src/main/java/com/shcho/myBlog/user/dto/UpdateUserNicknameRequestDto.java
@@ -1,0 +1,8 @@
+package com.shcho.myBlog.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateUserNicknameRequestDto(
+        @NotBlank String nickname
+) {
+}

--- a/src/main/java/com/shcho/myBlog/user/dto/UpdateUserPasswordRequestDto.java
+++ b/src/main/java/com/shcho/myBlog/user/dto/UpdateUserPasswordRequestDto.java
@@ -1,0 +1,9 @@
+package com.shcho.myBlog.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateUserPasswordRequestDto(
+        @NotBlank String oldPassword,
+        @NotBlank String rawPassword
+) {
+}

--- a/src/main/java/com/shcho/myBlog/user/dto/UpdateUserProfileImageRequestDto.java
+++ b/src/main/java/com/shcho/myBlog/user/dto/UpdateUserProfileImageRequestDto.java
@@ -1,9 +1,0 @@
-package com.shcho.myBlog.user.dto;
-
-import jakarta.validation.constraints.NotBlank;
-import org.hibernate.validator.constraints.URL;
-
-public record UpdateUserProfileImageRequestDto(
-        @NotBlank @URL String profileImageUrl
-) {
-}

--- a/src/main/java/com/shcho/myBlog/user/dto/UpdateUserProfileImageRequestDto.java
+++ b/src/main/java/com/shcho/myBlog/user/dto/UpdateUserProfileImageRequestDto.java
@@ -1,0 +1,9 @@
+package com.shcho.myBlog.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import org.hibernate.validator.constraints.URL;
+
+public record UpdateUserProfileImageRequestDto(
+        @NotBlank @URL String profileImageUrl
+) {
+}

--- a/src/main/java/com/shcho/myBlog/user/dto/UpdateUsernameRequestDto.java
+++ b/src/main/java/com/shcho/myBlog/user/dto/UpdateUsernameRequestDto.java
@@ -1,0 +1,8 @@
+package com.shcho.myBlog.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateUsernameRequestDto(
+        @NotBlank String username
+) {
+}

--- a/src/main/java/com/shcho/myBlog/user/dto/UserMeResponseDto.java
+++ b/src/main/java/com/shcho/myBlog/user/dto/UserMeResponseDto.java
@@ -5,13 +5,15 @@ import com.shcho.myBlog.user.entity.User;
 public record UserMeResponseDto(
         String username,
         String nickname,
-        String email
+        String email,
+        String profileImageUrl
 ) {
     public static UserMeResponseDto from(User user) {
         return new UserMeResponseDto(
                 user.getUsername(),
                 user.getNickname(),
-                user.getEmail()
+                user.getEmail(),
+                user.getProfileImageUrl()
         );
     }
 }

--- a/src/main/java/com/shcho/myBlog/user/entity/User.java
+++ b/src/main/java/com/shcho/myBlog/user/entity/User.java
@@ -68,6 +68,8 @@ public class User extends BaseEntity {
         this.profileImageUrl = profileImageUrl;
     }
 
+    public void deleteProfileImageUrl() { this.profileImageUrl = null; }
+
     public static User of(String username, String encodedPassword, String nickname, String email) {
         return User.builder()
                 .username(username)

--- a/src/main/java/com/shcho/myBlog/user/service/UserService.java
+++ b/src/main/java/com/shcho/myBlog/user/service/UserService.java
@@ -3,21 +3,25 @@ package com.shcho.myBlog.user.service;
 import com.shcho.myBlog.blog.entity.Blog;
 import com.shcho.myBlog.category.entity.Category;
 import com.shcho.myBlog.category.repository.CategoryRepository;
+import com.shcho.myBlog.common.service.MinioService;
 import com.shcho.myBlog.common.util.JwtProvider;
 import com.shcho.myBlog.libs.exception.CustomException;
-import com.shcho.myBlog.user.dto.UserSignInRequestDto;
-import com.shcho.myBlog.user.dto.UserSignUpRequestDto;
+import com.shcho.myBlog.user.dto.*;
 import com.shcho.myBlog.user.entity.User;
 import com.shcho.myBlog.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import static com.shcho.myBlog.common.entity.UploadType.PROFILE_IMAGE;
 import static com.shcho.myBlog.libs.exception.ErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class UserService {
 
     private static final String DEFAULT_CATEGORY_NAME = "미분류";
@@ -26,11 +30,12 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
     private final CategoryRepository categoryRepository;
+    private final MinioService minioService;
 
     @Transactional
     public User signUp(UserSignUpRequestDto requestDto) {
 
-        String username = requestDto.username();
+        String username = requestDto.username().trim();
         String password = requestDto.password();
         String nickname = requestDto.nickname();
         String email = requestDto.email();
@@ -77,6 +82,120 @@ public class UserService {
         if (!passwordEncoder.matches(password, user.getPassword())) {
             throw new CustomException(INVALID_USERNAME_OR_PASSWORD);
         }
+
+        return user;
+    }
+
+    @Transactional
+    public User updateUsername(Long userId, UpdateUsernameRequestDto requestDto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        String newUsername = requestDto.username().trim();
+
+        if (!newUsername.equals(user.getUsername()) &&
+                userRepository.existsByUsername(newUsername)) {
+            throw new CustomException(DUPLICATED_USERNAME);
+        }
+
+        user.updateUsername(newUsername);
+
+        return user;
+    }
+
+    @Transactional
+    public User updateUserPassword(Long userId, UpdateUserPasswordRequestDto requestDto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        String oldPassword = requestDto.oldPassword();
+        String newPassword = requestDto.rawPassword();
+
+        if (!passwordEncoder.matches(oldPassword, user.getPassword())) {
+            throw new CustomException(INVALID_OLD_PASSWORD);
+        }
+
+        String encodedPassword = passwordEncoder.encode(newPassword);
+
+        user.updatePassword(encodedPassword);
+
+        return user;
+    }
+
+    @Transactional
+    public User updateUserNickname(Long userId, UpdateUserNicknameRequestDto requestDto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        String newNickname = requestDto.nickname().trim();
+
+        if (!newNickname.equals(user.getNickname()) &&
+                userRepository.existsByNickname(newNickname)) {
+            throw new CustomException(DUPLICATED_NICKNAME);
+        }
+
+        user.updateNickname(newNickname);
+
+        return user;
+    }
+
+    @Transactional
+    public User updateUserEmail(Long userId, UpdateUserEmailRequestDto requestDto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        String newEmail = requestDto.email().trim();
+
+        if (!newEmail.equals(user.getEmail()) && userRepository.existsByEmail(newEmail)) {
+            throw new CustomException(DUPLICATED_EMAIL);
+        }
+
+        user.updateEmail(newEmail);
+
+        return user;
+    }
+
+    @Transactional
+    public User updateUserProfileImage(Long userId, MultipartFile file) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        String oldUrl = user.getProfileImageUrl();
+
+        String url = minioService.upload(userId, file, PROFILE_IMAGE);
+
+        user.updateProfileImageUrl(url);
+
+        if (oldUrl != null && !oldUrl.isBlank()) {
+            String oldObjectName = minioService.extractObjectNameFromUrl(oldUrl);
+
+            if (oldObjectName != null && !oldObjectName.isBlank()) {
+                try {
+                    minioService.deleteObject(oldObjectName);
+                } catch (Exception e) {
+                    log.warn("프로필 이미지 교체 중 이전 파일 삭제 실패. userId={}, oldObjectName={}",
+                            userId, oldObjectName, e);
+                }
+            }
+        }
+
+        return user;
+    }
+
+    @Transactional
+    public User deleteUserProfileImage(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        String oldUrl = user.getProfileImageUrl();
+        if (oldUrl != null && !oldUrl.isBlank()) {
+            String oldObjectName = minioService.extractObjectNameFromUrl(oldUrl);
+            if (oldObjectName != null && !oldObjectName.isBlank()) {
+                minioService.deleteObject(oldObjectName);
+            }
+        }
+
+        user.deleteProfileImageUrl();
 
         return user;
     }

--- a/src/main/java/com/shcho/myBlog/user/service/UserService.java
+++ b/src/main/java/com/shcho/myBlog/user/service/UserService.java
@@ -151,6 +151,10 @@ public class UserService {
 
         String newEmail = requestDto.email().trim();
 
+        if(newEmail.equals(user.getEmail())) {
+            throw new CustomException(SAME_EMAIL);
+        }
+
         if (!newEmail.equals(user.getEmail()) && userRepository.existsByEmail(newEmail)) {
             throw new CustomException(DUPLICATED_EMAIL);
         }

--- a/src/main/java/com/shcho/myBlog/user/service/UserService.java
+++ b/src/main/java/com/shcho/myBlog/user/service/UserService.java
@@ -155,7 +155,7 @@ public class UserService {
             throw new CustomException(SAME_EMAIL);
         }
 
-        if (!newEmail.equals(user.getEmail()) && userRepository.existsByEmail(newEmail)) {
+        if (userRepository.existsByEmail(newEmail)) {
             throw new CustomException(DUPLICATED_EMAIL);
         }
 

--- a/src/main/java/com/shcho/myBlog/user/service/UserService.java
+++ b/src/main/java/com/shcho/myBlog/user/service/UserService.java
@@ -93,8 +93,11 @@ public class UserService {
 
         String newUsername = requestDto.username().trim();
 
-        if (!newUsername.equals(user.getUsername()) &&
-                userRepository.existsByUsername(newUsername)) {
+        if(newUsername.equals(user.getUsername())) {
+            throw new CustomException(SAME_USERNAME);
+        }
+
+        if (userRepository.existsByUsername(newUsername)) {
             throw new CustomException(DUPLICATED_USERNAME);
         }
 
@@ -129,8 +132,10 @@ public class UserService {
 
         String newNickname = requestDto.nickname().trim();
 
-        if (!newNickname.equals(user.getNickname()) &&
-                userRepository.existsByNickname(newNickname)) {
+        if(newNickname.equals(user.getNickname())) {
+            throw new CustomException(SAME_NICKNAME);
+        }
+        if (userRepository.existsByNickname(newNickname)) {
             throw new CustomException(DUPLICATED_NICKNAME);
         }
 

--- a/src/test/java/com/shcho/myBlog/common/service/MinioServiceTest.java
+++ b/src/test/java/com/shcho/myBlog/common/service/MinioServiceTest.java
@@ -57,6 +57,7 @@ class MinioServiceTest {
         MultipartFile file = mock(MultipartFile.class);
         when(file.isEmpty()).thenReturn(false);
         when(file.getSize()).thenReturn(10L * 1024 * 1024 + 1);
+        when(file.getOriginalFilename()).thenReturn("image.jpg");
 
         // when & then
         CustomException exception = assertThrows(CustomException.class,

--- a/src/test/java/com/shcho/myBlog/user/service/UserServiceTest.java
+++ b/src/test/java/com/shcho/myBlog/user/service/UserServiceTest.java
@@ -324,7 +324,6 @@ class UserServiceTest {
     void updateUserPasswordFailedInvalidOldPassword() {
         // given
         User user = User.builder().userId(1L).password("encodedOldPassword").build();
-        String encodedNewPassword = "encodedNewPassword";
         UpdateUserPasswordRequestDto requestDto =
                 new UpdateUserPasswordRequestDto("wrongPassword", "newPassword");
 

--- a/src/test/java/com/shcho/myBlog/user/service/UserServiceTest.java
+++ b/src/test/java/com/shcho/myBlog/user/service/UserServiceTest.java
@@ -1,12 +1,10 @@
 package com.shcho.myBlog.user.service;
 
 import com.shcho.myBlog.category.repository.CategoryRepository;
+import com.shcho.myBlog.common.service.MinioService;
 import com.shcho.myBlog.common.util.JwtProvider;
 import com.shcho.myBlog.libs.exception.CustomException;
-import com.shcho.myBlog.user.dto.UpdateUserPasswordRequestDto;
-import com.shcho.myBlog.user.dto.UpdateUsernameRequestDto;
-import com.shcho.myBlog.user.dto.UserSignInRequestDto;
-import com.shcho.myBlog.user.dto.UserSignUpRequestDto;
+import com.shcho.myBlog.user.dto.*;
 import com.shcho.myBlog.user.entity.User;
 import com.shcho.myBlog.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -17,9 +15,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Optional;
 
+import static com.shcho.myBlog.common.entity.UploadType.PROFILE_IMAGE;
 import static com.shcho.myBlog.libs.exception.ErrorCode.*;
 import static com.shcho.myBlog.user.entity.Role.USER;
 import static org.junit.jupiter.api.Assertions.*;
@@ -37,6 +37,8 @@ class UserServiceTest {
     private JwtProvider jwtProvider;
     @Mock
     private CategoryRepository categoryRepository;
+    @Mock
+    private MinioService minioService;
     @InjectMocks
     private UserService userService;
 
@@ -260,7 +262,7 @@ class UserServiceTest {
 
         // then
         assertNotNull(updatedUser);
-        assertEquals(updatedUser.getUsername(), user.getUsername());
+        assertEquals("newUsername", updatedUser.getUsername());
     }
 
     @Test
@@ -337,6 +339,199 @@ class UserServiceTest {
         assertEquals(INVALID_OLD_PASSWORD, exception.getErrorCode());
     }
 
+    @Test
+    @DisplayName("닉네임 수정 성공")
+    void UpdateUserNicknameSuccess() {
+        // given
+        User user = User.builder().userId(1L).nickname("oldNickname").build();
+
+        UpdateUserNicknameRequestDto requestDto =
+                new UpdateUserNicknameRequestDto("newNickname");
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(userRepository.existsByNickname(requestDto.nickname()))
+                .thenReturn(false);
+
+        // when
+        User updatedUser = userService.updateUserNickname(user.getUserId(), requestDto);
+
+        // then
+        assertNotNull(updatedUser);
+        assertEquals("newNickname", updatedUser.getNickname());
+    }
+
+    @Test
+    @DisplayName("닉네임 수정 실패 - 이전과 동일한 닉네임")
+    void UpdateUserNicknameFailedSameNickname() {
+        // given
+        User user = User.builder().userId(1L).nickname("oldNickname").build();
+
+        UpdateUserNicknameRequestDto requestDto =
+                new UpdateUserNicknameRequestDto("oldNickname");
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> userService.updateUserNickname(user.getUserId(), requestDto));
+        assertEquals(SAME_NICKNAME, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("닉네임 수정 실패 - 닉네임 중복")
+    void UpdateUserNicknameFailedDuplicatedNickname() {
+        // given
+        User user = User.builder().userId(1L).nickname("oldNickname").build();
+
+        UpdateUserNicknameRequestDto requestDto =
+                new UpdateUserNicknameRequestDto("existsNickname");
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(userRepository.existsByNickname(requestDto.nickname()))
+                .thenReturn(true);
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> userService.updateUserNickname(user.getUserId(), requestDto));
+        assertEquals(DUPLICATED_NICKNAME, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("이메일 수정 성공")
+    void UpdateUserEmailSuccess() {
+        // given
+        User user = User.builder().userId(1L).email("oldEmail").build();
+
+        UpdateUserEmailRequestDto requestDto =
+                new UpdateUserEmailRequestDto("newEmail");
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(userRepository.existsByEmail(requestDto.email()))
+                .thenReturn(false);
+
+        // when
+        User updatedUser = userService.updateUserEmail(user.getUserId(), requestDto);
+
+        // then
+        assertNotNull(updatedUser);
+        assertEquals("newEmail", updatedUser.getEmail());
+    }
+
+    @Test
+    @DisplayName("이메일 수정 실패 - 이전과 동일한 이메일")
+    void UpdateUserEmailFailedSameEmail() {
+        // given
+        User user = User.builder().userId(1L).email("oldEmail").build();
+
+        UpdateUserEmailRequestDto requestDto =
+                new UpdateUserEmailRequestDto("oldEmail");
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> userService.updateUserEmail(user.getUserId(), requestDto));
+        assertEquals(SAME_EMAIL, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("이메일 수정 실패 - 이메일 중복")
+    void UpdateUserEmailFailedDuplicatedEmail() {
+        // given
+        User user = User.builder().userId(1L).email("oldEmail").build();
+
+        UpdateUserEmailRequestDto requestDto =
+                new UpdateUserEmailRequestDto("existsEmail");
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(userRepository.existsByEmail(requestDto.email()))
+                .thenReturn(true);
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> userService.updateUserEmail(user.getUserId(), requestDto));
+        assertEquals(DUPLICATED_EMAIL, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 수정 성공 - 기존 이미지 없음")
+    void UpdateUserProfileImageSuccessNoOldImage() {
+        // given
+        MultipartFile file = mock(MultipartFile.class);
+
+        User user = User.builder().userId(1L).profileImageUrl(null).build();
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(minioService.upload(user.getUserId(), file, PROFILE_IMAGE))
+                .thenReturn("https://minio/new.png");
+
+        // when
+        User updatedUser = userService.updateUserProfileImage(user.getUserId(), file);
+
+        // then
+        assertNotNull(updatedUser);
+        assertEquals("https://minio/new.png", updatedUser.getProfileImageUrl());
+
+        verify(minioService).upload(user.getUserId(), file, PROFILE_IMAGE);
+        verify(minioService, never()).extractObjectNameFromUrl(anyString());
+        verify(minioService, never()).deleteObject(anyString());
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 수정 성공 - 기존 이미지 삭제")
+    void UpdateUserProfileSuccessWithOldImage() {
+        // given
+        MultipartFile file = mock(MultipartFile.class);
+
+        String oldImageUrl = "https://minio/bucket/users/1/profile/old.png";
+        String oldObjectName = "users/1/profile/old.png";
+
+        User user = User.builder()
+                .userId(1L).profileImageUrl(oldImageUrl)
+                .build();
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(minioService.upload(user.getUserId(), file, PROFILE_IMAGE))
+                .thenReturn("https://minio/new.png");
+        when(minioService.extractObjectNameFromUrl(oldImageUrl))
+                .thenReturn(oldObjectName);
+
+        // when
+        User updatedUser = userService.updateUserProfileImage(user.getUserId(), file);
+
+        // then
+        assertEquals("https://minio/new.png", updatedUser.getProfileImageUrl());
+
+        verify(minioService).upload(user.getUserId(), file, PROFILE_IMAGE);
+        verify(minioService).extractObjectNameFromUrl(oldImageUrl);
+        verify(minioService).deleteObject(oldObjectName);
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 삭제 성공")
+    void DeleteUserProfileImageSuccess() {
+        // given
+        String oldImageUrl = "https://minio/bucket/users/1/profile/old.png";
+        String oldObjectName = "users/1/profile/old.png";
+
+        User user = User.builder()
+                .userId(1L).profileImageUrl(oldImageUrl)
+                .build();
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(minioService.extractObjectNameFromUrl(oldImageUrl))
+                .thenReturn(oldObjectName);
+
+        // when
+        User updatedUser = userService.deleteUserProfileImage(user.getUserId());
+
+        // then
+        assertNotNull(updatedUser);
+        assertNull(updatedUser.getProfileImageUrl());
+
+        verify(minioService).extractObjectNameFromUrl(oldImageUrl);
+        verify(minioService).deleteObject(oldObjectName);
+    }
 
     private UserSignUpRequestDto createTestRequest() {
         return new UserSignUpRequestDto("newUser", "password", "newNickname", "new@email.com");

--- a/src/test/java/com/shcho/myBlog/user/service/UserServiceTest.java
+++ b/src/test/java/com/shcho/myBlog/user/service/UserServiceTest.java
@@ -3,6 +3,8 @@ package com.shcho.myBlog.user.service;
 import com.shcho.myBlog.category.repository.CategoryRepository;
 import com.shcho.myBlog.common.util.JwtProvider;
 import com.shcho.myBlog.libs.exception.CustomException;
+import com.shcho.myBlog.user.dto.UpdateUserPasswordRequestDto;
+import com.shcho.myBlog.user.dto.UpdateUsernameRequestDto;
 import com.shcho.myBlog.user.dto.UserSignInRequestDto;
 import com.shcho.myBlog.user.dto.UserSignUpRequestDto;
 import com.shcho.myBlog.user.entity.User;
@@ -241,6 +243,101 @@ class UserServiceTest {
         assertEquals("", savedUser.getBlog().getIntro());
         assertEquals(savedUser.getNickname() + "의 블로그", savedUser.getBlog().getTitle());
     }
+
+    @Test
+    @DisplayName("username 수정 성공")
+    void updateUsernameSuccess() {
+        // given
+        User user = User.builder().userId(1L).username("oldUsername").build();
+
+        UpdateUsernameRequestDto requestDto = new UpdateUsernameRequestDto("newUsername");
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(userRepository.existsByUsername(requestDto.username())).thenReturn(false);
+
+        // when
+        User updatedUser = userService.updateUsername(user.getUserId(), requestDto);
+
+        // then
+        assertNotNull(updatedUser);
+        assertEquals(updatedUser.getUsername(), user.getUsername());
+    }
+
+    @Test
+    @DisplayName("username 수정 실패 - 이미 존재하는 username")
+    void updateUsernameFailedExistsUsername() {
+        // given
+        User user = User.builder().userId(1L).username("oldUsername").build();
+        UpdateUsernameRequestDto requestDto = new UpdateUsernameRequestDto("existUsername");
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(userRepository.existsByUsername(requestDto.username())).thenReturn(true);
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> userService.updateUsername(user.getUserId(), requestDto));
+
+        assertEquals(DUPLICATED_USERNAME, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("username 수정 실패 - 이전과 같은 닉네임")
+    void updateUsernameFailedNotNewUsername() {
+        // given
+        User user = User.builder().userId(1L).username("oldUsername").build();
+        UpdateUsernameRequestDto requestDto = new UpdateUsernameRequestDto("oldUsername");
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> userService.updateUsername(user.getUserId(), requestDto));
+
+        assertEquals(SAME_USERNAME, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("비밀번호 수정 성공")
+    void updateUserPasswordSuccess() {
+        // given
+        User user = User.builder().userId(1L).password("encodedOldPassword").build();
+        String encodedNewPassword = "encodedNewPassword";
+        UpdateUserPasswordRequestDto requestDto =
+                new UpdateUserPasswordRequestDto("oldPassword", "newPassword");
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches(requestDto.oldPassword(), user.getPassword()))
+                .thenReturn(true);
+        when(passwordEncoder.encode(requestDto.rawPassword()))
+                .thenReturn(encodedNewPassword);
+
+        // when
+        User updatedUser = userService.updateUserPassword(user.getUserId(), requestDto);
+
+        // then
+        assertNotNull(updatedUser);
+        assertEquals(encodedNewPassword, updatedUser.getPassword());
+    }
+
+    @Test
+    @DisplayName("비밀번호 수정 실패 - 비밀번호가 일치하지 않음")
+    void updateUserPasswordFailedInvalidOldPassword() {
+        // given
+        User user = User.builder().userId(1L).password("encodedOldPassword").build();
+        String encodedNewPassword = "encodedNewPassword";
+        UpdateUserPasswordRequestDto requestDto =
+                new UpdateUserPasswordRequestDto("wrongPassword", "newPassword");
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches(requestDto.oldPassword(), user.getPassword()))
+                .thenReturn(false);
+        // when & then
+        CustomException exception = assertThrows(CustomException.class,
+                () -> userService.updateUserPassword(user.getUserId(), requestDto));
+
+        assertEquals(INVALID_OLD_PASSWORD, exception.getErrorCode());
+    }
+
 
     private UserSignUpRequestDto createTestRequest() {
         return new UserSignUpRequestDto("newUser", "password", "newNickname", "new@email.com");


### PR DESCRIPTION
## ✅ 작업 내용
- 마이페이지 사용자 정보 수정 기능 구현
    - username 변경 기능 추가
    - 비밀번호 변경 기능 추가
    - 닉네임 변경 기능 추가
    - 이메일 변경 기능 추가
- 프로필 이미지 업로드 및 교체 기능 구현
    - 기존 이미지 존재 시 MinIO 객체 삭제 처리
    - 프로필 이미지 삭제 기능 구현
- GET /api/users/me 응답에 profileImageUrl 필드 추가
- UserService 단위 테스트 작성 및 검증 완료

## 🔧 변경사항
- UserService 수정
    - 사용자 정보 수정 로직 추가
    - 프로필 이미지 업로드/삭제 로직 추가
- UserController 수정
    - 사용자 정보 수정 API 추가
    - 프로필 이미지 관련 API 추가
- User 엔티티 수정
    - profileImageUrl 필드 반영
- 사용자 관련 DTO 추가
    - UpdateUsernameRequestDto
    - UpdateUserPasswordRequestDto
    - UpdateUserNicknameRequestDto
    - UpdateUserEmailRequestDto
- MinioService 연동 로직 추가
- UserServiceTest 작성 및 수정
    - 회원가입/로그인
    - 정보 수정 성공/실패 케이스
    - 프로필 이미지 교체/삭제 케이스

## 🧪 테스트
- UserService 단위 테스트 작성 완료
- 회원가입/로그인 성공 및 예외 케이스 검증
- 사용자 정보 수정 성공/중복/동일값 예외 케이스 검증
- 비밀번호 변경 시 기존 비밀번호 검증 로직 테스트
- 프로필 이미지 업로드 및 교체 시 MinIO 호출 검증
- 프로필 이미지 삭제 시 객체 정리 로직 검증

## 📌 관련 이슈
- Closes #48 
